### PR TITLE
Add note in README about material-ui icons

### DIFF
--- a/docs/src/pages/getting-started/templates/dashboard/README.md
+++ b/docs/src/pages/getting-started/templates/dashboard/README.md
@@ -3,3 +3,6 @@
 ## Usage
 
 Simply copy the files into your project, or one of the [example applications](https://github.com/mui-org/material-ui/tree/master/examples), and import and use the `Dashboard` component.
+
+Note: If you are using the example templates, don't forget to import **material-ui-icons**, which is not part of the core material-ui package:
+ ```npm install --save material-ui-icons```


### PR DESCRIPTION
Added a note in the Readme for the Dashboards template, for users who may have only added the base npm package for material ui but not added the material icons package.

<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [Y] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/master/CONTRIBUTING.md#submitting-a-pull-request).
